### PR TITLE
Alternatives fix - one argument forgotten

### DIFF
--- a/src/Geolocation/Google/GeocodingResponse.php
+++ b/src/Geolocation/Google/GeocodingResponse.php
@@ -258,7 +258,7 @@ class GeocodingResponse extends Object
 			) {
 				return NULL;
 			}
-			return new $class($client, array($alternative));
+			return new $class($client, array($alternative), $this->options);
 		}, $this->alternatives), function ($alternative) { return (bool) $alternative;});
 	}
 


### PR DESCRIPTION
Pokud se nepletu, zapomněl se jeden argument. Při zavolání to vyhodí warning.
